### PR TITLE
Remove madhouse_utils as dependency to madhouse_helloworld

### DIFF
--- a/classes/Madhouse/HelloWorld/Controllers/Web.php
+++ b/classes/Madhouse/HelloWorld/Controllers/Web.php
@@ -20,7 +20,7 @@ class Madhouse_HelloWorld_Controllers_Web extends WebSecBaseModel {
  */
 public function doModel() {
 	switch(Params::getParam("route")) {
-		case mdh_current_plugin_name() . "_show":
+		case "madhouse_helloworld_show":
 			// Get our first message from our model layer.
 			$message = Madhouse_HelloWorld_Models_Message::newInstance()->findByPrimaryKey(1);
 			// Exports it to make it available to the view.
@@ -31,7 +31,7 @@ public function doModel() {
 		break;
 		default:
 			// Don't know what to do. Pretend not to exist.
-			osc_add_flash_error_message(__("Oops! We got confused at some point. Try to refresh the page.", mdh_current_plugin_name()));
+			osc_add_flash_error_message(__("Oops! We got confused at some point. Try to refresh the page.", "madhouse_helloworld"));
 			$this->redirectTo(osc_base_url());
 		break;
 	}

--- a/classes/Madhouse/HelloWorld/Controllers/WebLegacy.php
+++ b/classes/Madhouse/HelloWorld/Controllers/WebLegacy.php
@@ -48,7 +48,10 @@ class Madhouse_HelloWorld_Controllers_WebLegacy extends WebSecBaseModel {
 	 * @see oc-includes/osclass/controller.
 	 */
 	public function doView($file) {
-		Madhouse_Utils_Controllers::doView($file);
+		osc_run_hook("before_html");
+		osc_current_web_theme_path($file);
+		Session::newInstance()->_clearVariables();
+		osc_run_hook("after_html");
 	}
 }
 

--- a/classes/Madhouse/HelloWorld/Controllers/WebLegacy.php
+++ b/classes/Madhouse/HelloWorld/Controllers/WebLegacy.php
@@ -35,7 +35,7 @@ class Madhouse_HelloWorld_Controllers_WebLegacy extends WebSecBaseModel {
 			break;
 			default:
 				// Don't know what to do. Pretend not to exist.
-				osc_add_flash_error_message(__("Oops! We got confused at some point. Try to refresh the page.", mdh_current_plugin_name()));
+				osc_add_flash_error_message(__("Oops! We got confused at some point. Try to refresh the page.", "madhouse_helloworld"));
 				$this->redirectTo(osc_base_url());
 			break;
 		}

--- a/helpers/hHelloWorld.php
+++ b/helpers/hHelloWorld.php
@@ -8,9 +8,9 @@
 function mdh_helloworld_show_url()
 {
 	if(osc_version() >= 330) {
-		return osc_route_url(mdh_current_plugin_name() . "_show");
+		return osc_route_url("madhouse_helloworld_show");
 	}
-	return osc_ajax_plugin_url(mdh_current_plugin_name() . "/main.php") . "&do=show";
+	return osc_ajax_plugin_url("madhouse_helloworld/main.php") . "&do=show";
 }
 
 /**
@@ -30,7 +30,7 @@ function mdh_helloworld_get_message()
  */
 function mdh_is_helloworld()
 {
-	if(preg_match('/^' . mdh_current_plugin_name() . '.*$/', Params::getParam("route"))) {
+	if(preg_match('/^madhouse_helloworld.*$/', Params::getParam("route"))) {
 		return true;
 	}
 	return false;

--- a/helpers/hUtils.php
+++ b/helpers/hUtils.php
@@ -1,0 +1,36 @@
+<?php
+
+if (!function_exists("mdh_import_sql")) {
+    /**
+     * Imports an SQL file into the Osclass database.
+     *
+     * Really useful when installing a plugin to create its model schema,
+     * or delete its schema on uninstall. Avoid to have an install/uninstall
+     * method in every plugin data-access object.
+     *
+     * @param   $path absolute file path to the SQL file to import.
+     *
+     * @return  void
+     *
+     * @throws  Exception if the import fails.
+     *
+     * @see     Madhouse_Utils_Models::import
+     */
+    function mdh_import_sql($path)
+    {
+        // Try to import it. Throws Exception if failure.
+        $conn = DBConnectionClass::newInstance()->getOsclassDb();
+        $dao = new DBCommandClass($conn);
+
+        // // Get the content of the file.
+        $sql = file_get_contents($path);
+
+        // Strip comments.
+        // Makes DAO go wazoo.
+        $sql = preg_replace('/\-\-.*$/m', '', $sql);
+
+        if (! $dao->importSQL($sql)) {
+            throw new Exception("Import failed with: '" . $dao->getErrorDesc() . "'");
+        }
+    }
+}

--- a/index.php
+++ b/index.php
@@ -15,7 +15,7 @@ Author URI: http://wearemadhouse.wordpress.com/
  * ==========================================================================
  */
 
-mdh_current_plugin_path("oc-load.php");
+require_once __DIR__ . "/oc-load.php";
 
 /*
  * ==========================================================================
@@ -29,7 +29,7 @@ mdh_current_plugin_path("oc-load.php");
  * @returns void.
  */
 function mdh_helloworld_install() {
-	mdh_import_sql(mdh_current_plugin_path("assets/model/install.sql", false));
+	//mdh_import_sql(__DIR__ . "/assets/model/install.sql");
 }
 osc_register_plugin(osc_plugin_path(__FILE__), 'mdh_helloworld_install');
 
@@ -39,7 +39,7 @@ osc_register_plugin(osc_plugin_path(__FILE__), 'mdh_helloworld_install');
  * @returns void.
  */
 function mdh_helloworld_uninstall() {
-	mdh_import_sql(mdh_current_plugin_path("assets/model/uninstall.sql", false));
+	//mdh_import_sql(__DIR__ . "/assets/model/uninstall.sql");
 }
 osc_add_hook(osc_plugin_path(__FILE__) . '_uninstall', 'mdh_helloworld_uninstall');
 
@@ -60,10 +60,10 @@ if(osc_version() >= 330) {
 	osc_add_hook("custom_controller", "mdh_helloworld_controller");
 
 	osc_add_route(
-	    mdh_current_plugin_name() . "_show",
+	    "madhouse_helloworld_show",
 	    'helloworld/show/?',
 	    'helloworld/show/',
-	    mdh_current_plugin_name() . '/views/web/show.php'
+	    "madhouse_helloworld/views/web/show.php"
 	);
 }
 

--- a/index.php
+++ b/index.php
@@ -29,7 +29,7 @@ require_once __DIR__ . "/oc-load.php";
  * @returns void.
  */
 function mdh_helloworld_install() {
-	//mdh_import_sql(__DIR__ . "/assets/model/install.sql");
+	mdh_import_sql(__DIR__ . "/assets/model/install.sql");
 }
 osc_register_plugin(osc_plugin_path(__FILE__), 'mdh_helloworld_install');
 
@@ -39,7 +39,7 @@ osc_register_plugin(osc_plugin_path(__FILE__), 'mdh_helloworld_install');
  * @returns void.
  */
 function mdh_helloworld_uninstall() {
-	//mdh_import_sql(__DIR__ . "/assets/model/uninstall.sql");
+	mdh_import_sql(__DIR__ . "/assets/model/uninstall.sql");
 }
 osc_add_hook(osc_plugin_path(__FILE__) . '_uninstall', 'mdh_helloworld_uninstall');
 

--- a/main.php
+++ b/main.php
@@ -4,7 +4,7 @@
  * @deprecated Use routes instead. The file is kept for legacy purpose.
  */
 
-if(! mdh_plugin_is_ready(mdh_current_plugin_name())) {
+if(! mdh_plugin_is_ready("madhouse_helloworld")) {
 	mdh_handle_error_ugly();
 }
 

--- a/oc-load.php
+++ b/oc-load.php
@@ -4,6 +4,7 @@ require_once __DIR__ . "/classes/Madhouse/HelloWorld/Models/Message.php";
 require_once __DIR__ . "/classes/Madhouse/HelloWorld/Controllers/Web.php";
 require_once __DIR__ . "/classes/Madhouse/HelloWorld/Controllers/WebLegacy.php";
 
+require_once __DIR__ . "/helpers/hUtils.php";
 require_once __DIR__ . "/helpers/hHelloWorld.php";
 
 ?>

--- a/oc-load.php
+++ b/oc-load.php
@@ -1,9 +1,9 @@
 <?php
 
-mdh_current_plugin_path("classes/Madhouse/HelloWorld/Models/Message.php");
-mdh_current_plugin_path("classes/Madhouse/HelloWorld/Controllers/Web.php");
-mdh_current_plugin_path("classes/Madhouse/HelloWorld/Controllers/WebLegacy.php");
+require_once __DIR__ . "/classes/Madhouse/HelloWorld/Models/Message.php";
+require_once __DIR__ . "/classes/Madhouse/HelloWorld/Controllers/Web.php";
+require_once __DIR__ . "/classes/Madhouse/HelloWorld/Controllers/WebLegacy.php";
 
-mdh_current_plugin_path("helpers/hHelloWorld.php");
+require_once __DIR__ . "/helpers/hHelloWorld.php";
 
 ?>

--- a/views/web/show.php
+++ b/views/web/show.php
@@ -1,5 +1,4 @@
-<?php Madhouse_Utils_Plugins::overrideView(); ?>
 <p>
-    <?php _e("Here's your message :", "your-theme"); ?>&nbsp;
+    <?php _e("Here's your message :", "madhouse_helloworld"); ?>&nbsp;
     &laquo;<?php echo mdh_helloworld_get_message(); ?>&raquo;
 </p>


### PR DESCRIPTION
madhouse_helloworld has no dependency anymore to any other library / plugin now.
### What's madhouse_utils ?

Madhouse Utils is a package that serve as base to all osclass plugins. It was a plugin itself in its earlier versions and is now a package (managed through composer).

More informations (work in progress) [here](https://wearemadhouse.wordpress.com/portfolio/madhouse-utils/).
### Why remove madhouse_utils ?

I believe that introducing the complexity of composer and a dependency to a third-party package breaks the purpose of a 'How to develop Osclass Plugins 101' tutorial. Moreover, Madhouse Utils is _still in the process to become open source_.
